### PR TITLE
🐛 Fix Invoice deserialization: add missing prepayment_invoice sub_type [TDD-3531]

### DIFF
--- a/.changeset/quiet-otters-cheer.md
+++ b/.changeset/quiet-otters-cheer.md
@@ -1,0 +1,5 @@
+---
+"@deegitalbe/laravel-trustup-io-storecove": patch
+---
+
+Fix Invoice model deserialization: add missing `prepayment_invoice` value to `sub_type` allowable values (received advance-payment invoices via Peppol)

--- a/src/Model/Invoice.php
+++ b/src/Model/Invoice.php
@@ -456,6 +456,7 @@ class Invoice implements ModelInterface, ArrayAccess
     const SUB_TYPE_CORRECTIONINVOICE = 'correctioninvoice';
     const SUB_TYPE_SELFBILLING = 'selfbilling';
     const SUB_TYPE_SELF_BILLED_INVOICE = 'self_billed_invoice';
+    const SUB_TYPE_PREPAYMENT_INVOICE = 'prepayment_invoice';
     const TAX_SYSTEM_AMOUNTS = 'tax_line_amounts';
     const TAX_SYSTEM_PERCENTAGES = 'tax_line_percentages';
     const TRANSACTION_TYPE_B2B = 'b2b';
@@ -550,6 +551,7 @@ class Invoice implements ModelInterface, ArrayAccess
             self::SUB_TYPE_CORRECTIONINVOICE,
             self::SUB_TYPE_SELFBILLING,
             self::SUB_TYPE_SELF_BILLED_INVOICE,
+            self::SUB_TYPE_PREPAYMENT_INVOICE,
         ];
     }
     


### PR DESCRIPTION
## Problem

Storecove returns `prepayment_invoice` as the `sub_type` for advance-payment invoices received via Peppol. This value was missing from `Invoice::getSubTypeAllowableValues()`, so `setSubType()` threw `InvalidArgumentException` during JSON deserialization of received documents.

In worksite-api this crashed `CreateExpenseFromReceivingJob` for every prepayment invoice received, leaving receivings permanently stuck in `failed` status. The daily retry command re-dispatched them indefinitely, inflating Flare error counts (20,526 occurrences on error #8224967).

## Fix

- Add `const SUB_TYPE_PREPAYMENT_INVOICE = 'prepayment_invoice';`
- Add it to `getSubTypeAllowableValues()`

This covers both call sites (`setSubType()` and `listInvalidProperties()`).

## Precedent

Same class of bug as TDD-3515 (`d736972` — missing enum value on `Reference` deserialization), fixed the same way.

## Linear

TDD-3531 — https://linear.app/trustup/issue/TDD-3531

Parent of bug report BUG-207 (tenant SRL PETIT & MARTINS, receiving `38632895-d8f7-4713-9b6c-18e2699d8fd0`), which will be auto-reprocessed by the retry command once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)