### PR TITLE
TDD-3605 - Main

### DIFF
--- a/.changeset/teal-lions-hum.md
+++ b/.changeset/teal-lions-hum.md
@@ -2,4 +2,6 @@
 "@deegitalbe/laravel-trustup-io-storecove": patch
 ---
 
-Accept text/csv as a valid attachment mime type so inbound Peppol documents carrying a CSV attachment deserialize instead of throwing during received-document parsing.
+Accept the HWE quantity unit code and the csv and xlsx attachment mime types on inbound documents.
+
+A received document was discarded whole when a single line item or attachment carried a value outside a generated allow-list. Three such values were stranding real invoices: HWE (a labour unit code sent by staffing agencies, alongside the already-accepted LH and DAY), csv attachments, and xlsx attachments.

--- a/.changeset/teal-lions-hum.md
+++ b/.changeset/teal-lions-hum.md
@@ -1,0 +1,5 @@
+---
+"@deegitalbe/laravel-trustup-io-storecove": patch
+---
+
+Accept text/csv as a valid attachment mime type so inbound Peppol documents carrying a CSV attachment deserialize instead of throwing during received-document parsing.

--- a/src/Model/Attachment.php
+++ b/src/Model/Attachment.php
@@ -187,6 +187,7 @@ class Attachment implements ModelInterface, ArrayAccess
     const MIME_TYPE_PDF = 'application/pdf';
     const MIME_TYPE_XML = 'application/xml';
     const MIME_TYPE_CSV = 'text/csv';
+    const MIME_TYPE_XLSX = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
 
 
     
@@ -201,6 +202,7 @@ class Attachment implements ModelInterface, ArrayAccess
             self::MIME_TYPE_PDF,
             self::MIME_TYPE_XML,
             self::MIME_TYPE_CSV,
+            self::MIME_TYPE_XLSX,
         ];
     }
     

--- a/src/Model/Attachment.php
+++ b/src/Model/Attachment.php
@@ -186,7 +186,8 @@ class Attachment implements ModelInterface, ArrayAccess
 
     const MIME_TYPE_PDF = 'application/pdf';
     const MIME_TYPE_XML = 'application/xml';
-    
+    const MIME_TYPE_CSV = 'text/csv';
+
 
     
     /**
@@ -199,6 +200,7 @@ class Attachment implements ModelInterface, ArrayAccess
         return [
             self::MIME_TYPE_PDF,
             self::MIME_TYPE_XML,
+            self::MIME_TYPE_CSV,
         ];
     }
     

--- a/src/Model/InvoiceLine.php
+++ b/src/Model/InvoiceLine.php
@@ -1200,6 +1200,7 @@ class InvoiceLine implements ModelInterface, ArrayAccess
     const QUANTITY_UNIT_CODE_HPA = 'HPA';
     const QUANTITY_UNIT_CODE_HTZ = 'HTZ';
     const QUANTITY_UNIT_CODE_HUR = 'HUR';
+    const QUANTITY_UNIT_CODE_HWE = 'HWE';
     const QUANTITY_UNIT_CODE_IA = 'IA';
     const QUANTITY_UNIT_CODE_IE = 'IE';
     const QUANTITY_UNIT_CODE_INH = 'INH';
@@ -3690,6 +3691,7 @@ class InvoiceLine implements ModelInterface, ArrayAccess
             self::QUANTITY_UNIT_CODE_HPA,
             self::QUANTITY_UNIT_CODE_HTZ,
             self::QUANTITY_UNIT_CODE_HUR,
+            self::QUANTITY_UNIT_CODE_HWE,
             self::QUANTITY_UNIT_CODE_IA,
             self::QUANTITY_UNIT_CODE_IE,
             self::QUANTITY_UNIT_CODE_INH,

--- a/tests/Unit/ReceivedDocumentDeserializationTest.php
+++ b/tests/Unit/ReceivedDocumentDeserializationTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Deegitalbe\LaravelTrustupIoStorecove\Tests\Unit;
+
+use Deegitalbe\LaravelTrustupIoStorecove\Model\Attachment;
+use Deegitalbe\LaravelTrustupIoStorecove\Model\InvoiceLine;
+use Deegitalbe\LaravelTrustupIoStorecove\Model\Transportable;
+use Deegitalbe\LaravelTrustupIoStorecove\ObjectSerializer;
+use Deegitalbe\LaravelTrustupIoStorecove\Tests\TestCase;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Deserialization of received documents through the same path as
+ * ReceivedDocumentsApi::getReceivedDocument(), whose returnType is Transportable.
+ *
+ * A rejected enum value anywhere in the payload aborts the whole document, so these
+ * cases are about not losing an invoice over one unrecognised code.
+ */
+class ReceivedDocumentDeserializationTest extends TestCase
+{
+    public function test_it_deserializes_a_labour_hour_unit_code(): void
+    {
+        $invoice = $this->deserialize($this->payload(unitCode: 'HWE'))
+            ->getDocument()
+            ->getInvoice();
+
+        $this->assertEquals('HWE', $invoice->getInvoiceLines()[0]->getQuantityUnitCode());
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function supportedMimeTypes(): array
+    {
+        return [
+            'pdf' => [Attachment::MIME_TYPE_PDF],
+            'xml' => [Attachment::MIME_TYPE_XML],
+            'csv' => [Attachment::MIME_TYPE_CSV],
+            'xlsx' => [Attachment::MIME_TYPE_XLSX],
+        ];
+    }
+
+    #[DataProvider('supportedMimeTypes')]
+    public function test_it_deserializes_every_supported_attachment_mime_type(string $mimeType): void
+    {
+        $invoice = $this->deserialize($this->payload(mimeType: $mimeType))
+            ->getDocument()
+            ->getInvoice();
+
+        $this->assertEquals($mimeType, $invoice->getAttachments()[0]->getMimeType());
+    }
+
+    public function test_it_still_rejects_an_unknown_unit_code(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("/'quantity_unit_code'/");
+
+        $this->deserialize($this->payload(unitCode: 'NOT_A_CODE'));
+    }
+
+    public function test_it_still_rejects_an_unknown_mime_type(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("/'mime_type'/");
+
+        $this->deserialize($this->payload(mimeType: 'image/gif'));
+    }
+
+    public function test_it_keeps_accepting_a_previously_allowed_unit_code(): void
+    {
+        $invoice = $this->deserialize($this->payload(unitCode: InvoiceLine::QUANTITY_UNIT_CODE_HUR))
+            ->getDocument()
+            ->getInvoice();
+
+        $this->assertEquals('HUR', $invoice->getInvoiceLines()[0]->getQuantityUnitCode());
+    }
+
+    private function deserialize(string $json): Transportable
+    {
+        return ObjectSerializer::deserialize(json_decode($json), '\\'.Transportable::class, []);
+    }
+
+    private function payload(
+        string $unitCode = InvoiceLine::QUANTITY_UNIT_CODE_EA,
+        string $mimeType = Attachment::MIME_TYPE_PDF,
+    ): string {
+        return json_encode([
+            'document' => [
+                'document_type' => 'invoice',
+                'invoice' => [
+                    'sub_type' => 'invoice',
+                    'invoice_number' => 'TDD-3713',
+                    'issue_date' => '2026-07-22',
+                    'invoice_lines' => [[
+                        'description' => 'labour',
+                        'quantity' => 1,
+                        'quantity_unit_code' => $unitCode,
+                        'amount_excluding_tax' => 100.0,
+                    ]],
+                    'attachments' => [[
+                        'document' => base64_encode('placeholder-bytes'),
+                        'mime_type' => $mimeType,
+                        'filename' => 'annex.bin',
+                    ]],
+                ],
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
## What

Accept three values that inbound Peppol documents legitimately carry but the generated models rejected.

| value | model |
|---|---|
| `text/csv` | `Attachment::getMimeTypeAllowableValues()` |
| `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` (xlsx) | `Attachment::getMimeTypeAllowableValues()` |
| `HWE` quantity unit code | `InvoiceLine::getQuantityUnitCodeAllowableValues()` |

Four lines of source change across two files.

## Why

The generated models enforce closed enum allow-lists in their setters, and those setters also run during deserialization of **received** documents (`ObjectSerializer::deserialize` -> `setXxx`). One out-of-list value anywhere in the payload throws and discards the **entire invoice**, not just the field.

Two clients hit this:

- Tenant `6b4cd78c` (BUG-225): 4 documents still unprocessed, oldest 2026-06-02. csv.
- Tenant `99d5e0fb` (REQ-489): **26 documents lost between 2026-03-11 and 2026-08-03**, while the same tenant's other 609 receivings succeeded. 25 on `HWE`, 1 on xlsx.

`HWE` is a labour unit code sent by staffing agencies. `LH` and `DAY` were already accepted; `HWE` was absent entirely, so every weekly invoice from that supplier was dropped for five months.

## Scope

Deliberately narrow: the three observed values and nothing else.

An earlier revision of this branch also rewrote all 85 enum validation messages to name the rejected value, since today they print only the accepted list (roughly 2000 codes for `quantity_unit_code`) and each new instance therefore has to be identified by replaying the document against the live Storecove API. That was dropped as scope creep given this package is on its way out with the Storecove migration. The replay method is documented in TDD-3605 for whoever hits the next one.

This PR was also widened from csv-only to absorb TDD-3713, which covered the xlsx and HWE halves of the same defect and has been cancelled. Splitting one mechanism across two branches touching the same lines only created conflicts.

## Tests

`tests/Unit/ReceivedDocumentDeserializationTest.php`, 8 cases through the real `ObjectSerializer` path into `Transportable`, the same path `ReceivedDocumentsApi::getReceivedDocument()` uses:

- HWE deserializes
- all four supported mime types deserialize (pdf, xml, csv, xlsx)
- unknown unit code and unknown mime type still throw
- a previously-valid unit code still works, guarding the allow-list edits

8 passed. Verified failing before the fix and passing after.

Note: `tests/Feature/ExampleFeatureTest.php` has one pre-existing failure, `wrapper can catch storecove api error and format properly`. It issues a live POST to the Storecove API and asserts a 403; the API currently answers 401, so it is credential-dependent. Confirmed failing at `99d2da3` with none of this branch's changes applied. Untouched here.

## After merge

Tag a patch release, then bump the `^2.2` constraint in worksite-api. Affected receivings reprocess automatically: `einvoicing:expense:from-retryable-receiving` runs daily and selects both `FAILED` and `PENDING`, so no manual data patch. Storecove still holds every affected document, including the March ones.

Linear: TDD-3605